### PR TITLE
Update lava.dm igniting things in hands

### DIFF
--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -23,8 +23,11 @@
 /turf/open/lava/airless
 	initial_gas_mix = "TEMP=2.7"
 
-/turf/open/lava/Entered(atom/movable/AM)
-	if(burn_stuff(AM))
+/turf/open/lava/Entered(atom/movable/AM, atom/oldLoc)
+	if (!oldLoc || (oldLoc && !isobj(oldLoc) && !ismob(oldLoc))) //entered from null or not (/obj and /mob) then
+		if(burn_stuff(AM))
+			START_PROCESSING(SSobj, src)
+	else //if entered from /mob or /obj, start processing lava turf, burn_stuff applies to AM in process() if it stays on lava turf
 		START_PROCESSING(SSobj, src)
 
 /turf/open/lava/hitby(atom/movable/AM)


### PR DESCRIPTION
[Changelogs]: #Лава больше не поджигает вещи у вас в руках.
:cl:
tweak: Добавление параметра oldLoc проц. Entered(), отмена обработки первого тика в случае попадания из моба или объекта. Как результат - вещи, доставаемые из рюкзаков/снятые/etc. не загораются. При кидании чего-либо оно так же сначала дропается на лаву, а затем уже летит.
Минус - дропнутые в лаву вещи загораются не моментально.

/:cl:

[why]: # Грустно, когда сгорает последняя кирка.
