### PR TITLE
rhtml_decode fix

### DIFF
--- a/code/__HELPERS/text_ru.dm
+++ b/code/__HELPERS/text_ru.dm
@@ -89,7 +89,7 @@ JSON на выходе - строго ASCII, строки закодированы в Unicode, все Unicode-символ
 /proc/rhtml_decode(var/t)
 	t = replacetext(t, "&#x044f;", "€")
 	t = replacetext(t, "&#255;", "€")
-	//t = rhtml_decode(t) // Ќеебу, зачем оно тут, но если его тут оставл€ть, оно уходит в бесконечную рекурсию и валитс€ по соответствующему рантайму.
+	t = html_decode(t) //ѕодозреваю, именно это имелось ввиду, а не rhtml_decode(t)
 	return t
 
 

--- a/code/__HELPERS/text_ru.dm
+++ b/code/__HELPERS/text_ru.dm
@@ -89,7 +89,7 @@ JSON на выходе - строго ASCII, строки закодированы в Unicode, все Unicode-символ
 /proc/rhtml_decode(var/t)
 	t = replacetext(t, "&#x044f;", "я")
 	t = replacetext(t, "&#255;", "я")
-	t = rhtml_decode(t)
+	//t = rhtml_decode(t) // Неебу, зачем оно тут, но если его тут оставлять, оно уходит в бесконечную рекурсию и валится по соответствующему рантайму.
 	return t
 
 


### PR DESCRIPTION
[Changelogs]:

:cl: optional name here
fix: fixed rhtml_decode (убрал одну букву в нужном месте, теперь речь пьяниц не рантаймит, а корректно обрабатывается, без приплетения многосимвольных замен "я")
/:cl:

[why]: because runtimes