### PR TITLE
Movement unfuck

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/necropolis_tendril.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/necropolis_tendril.dm
@@ -13,6 +13,7 @@
 	icon_dead = "tendril"
 	faction = list("mining")
 	weather_immunities = list("lava","ash")
+	mob_size = MOB_SIZE_LARGE
 	health = 250
 	maxHealth = 250
 	max_mobs = 3

--- a/code/modules/mob/living/simple_animal/spawner.dm
+++ b/code/modules/mob/living/simple_animal/spawner.dm
@@ -21,6 +21,7 @@
 	maxbodytemp = 350
 	layer = BELOW_MOB_LAYER
 	sentience_type = SENTIENCE_BOSS
+	mob_size = MOB_SIZE_LARGE
 
 
 /mob/living/simple_animal/hostile/spawner/Destroy()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -10,6 +10,15 @@
 			return TRUE
 	return (!mover.density || !density || lying)
 
+//Does mob allows other mob M to pass over it
+//If it's hostile to M and moves not worse than M AND it's non-restrained and not on help intent, it doesn't
+/mob/proc/allows_pass(mob/M)
+	return movement_type < M.movement_type || faction_check(M) && (a_intent == INTENT_HELP || restrained())
+
+//Will mob try to move trough other mob
+//so if it's non-restrained and not on help intent, it won't
+/mob/proc/wants_pass()
+	return a_intent == INTENT_HELP || restrained()
 
 //The byond version of these verbs wait for the next tick before acting.
 //	instant verbs however can run mid tick or even during the time between ticks.


### PR DESCRIPTION
Собственно, ТГшники рефакторили код передвижения, добавили рантаймов и багов, но и интересную идею. Я допилил, и вот, что получается:
Если способ передвижения у движущегося моба лучше, чем у того, с которым он сталкивается (например, он летит, сталкивается с наземным), и либо оный моб связан, либо у него интент - хелп, то оный моб банально пройдет мимо (пролетит над наземным, если рассматривать тот пример). Исключение - недвижимые гигантские мобы, для прохода мимо них нужно быть летающим.
Если же способ передвижения НЕ лучше, то зависит еще от моба, с которым сталкиваемся, а именно он должен быть либо связан, либо на хелп интенте и не враждебен (иначе моб активно препятствует проходу мимо него). 
В итоге и всякие факапы фиксятся (например, проход сквозь дракона, который какого-то хера летает, даже когда на земле), и оная идея привносится (можно пролетать над наземными мобами, если умеешь летать).

[Changelogs]:
:cl:
tweak: Допилил механизм определения движения при столкновении двух мобов
fix: Пофиксил рантайм, всплывающий при проходе сквозь моба при пулле предмета
/:cl:

[why]: Потому что уебаны-тгшники своим рефакторингом дофига всего сломали
