### PR TITLE
Выпилил проигрывание спейсассхола по прилету шаттла.

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -393,7 +393,6 @@
 				dock_id(destination_dock)
 				mode = SHUTTLE_ENDGAME
 				timer = 0
-				world << 'sound/jukebox/spaceasshole.ogg'
 
 /obj/docking_port/mobile/emergency/transit_failure()
 	..()


### PR DESCRIPTION
This reverts commit 6e77e4ff4e9c3e2178d29714b3efd1924c859ab4.
Задалбывает, ибо не выключается через префы и включается каждый раунд.